### PR TITLE
Fix bug and update arguments in GridCells

### DIFF
--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -765,6 +765,7 @@ class GridCells(Neurons):
         return firingrate
 
     def set_phase_offsets(self):
+        """Set non-random phase_offsets. Most offsets (cell number: x*y) are grid-like, while the remainings (cell number: n - x*y) are random."""
         n_x = int(np.sqrt(self.n))
         n_y = self.n // n_x
         n_remaining = self.n - n_x * n_y

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -715,6 +715,8 @@ class GridCells(Neurons):
         self.w = np.array(w)
         if self.random_gridscales == True:
             self.gridscales = np.random.rayleigh(scale=self.gridscale, size=self.n)
+        else:
+            self.gridscales = np.full(self.n, fill_value=self.gridscale)
         if verbose is True:
             print(
                 "GridCells successfully initialised. You can also manually set their gridscale (GridCells.gridscales), offsets (GridCells.phase_offset) and orientations (GridCells.w1, GridCells.w2,GridCells.w3 give the cosine vectors)"

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -690,6 +690,7 @@ class GridCells(Neurons):
             "gridscale": 0.45,
             "random_orientations": True,
             "random_gridscales": True,
+            "random_phase_offsets": True,
             "min_fr": 0,
             "max_fr": 1,
             "name": "GridCells",
@@ -703,7 +704,10 @@ class GridCells(Neurons):
         assert (
             self.Agent.Environment.dimensionality == "2D"
         ), "grid cells only available in 2D"
-        self.phase_offsets = np.random.uniform(0, self.gridscale, size=(self.n, 2))
+        if self.random_phase_offsets == True:
+            self.phase_offsets = np.random.uniform(0, self.gridscale, size=(self.n, 2))
+        else:
+            self.phase_offsets = self.set_phase_offsets()
         w = []
         for i in range(self.n):
             w1 = np.array([1, 0])
@@ -758,6 +762,22 @@ class GridCells(Neurons):
             firingrate * (self.max_fr - self.min_fr) + self.min_fr
         )  # scales from being between [0,1] to [min_fr, max_fr]
         return firingrate
+
+    def set_phase_offsets(self):
+        n_x = int(np.sqrt(self.n))
+        n_y = self.n // n_x
+        n_remaining = self.n - n_x * n_y
+
+        dx = self.gridscale / n_x
+        dy = self.gridscale / n_y
+
+        grid = np.mgrid[(0 + dx/2):(self.gridscale - dx/2):(n_x*1j), (0 + dy/2):(self.gridscale - dy/2):(n_y*1j)]
+        grid = grid.reshape(2, -1).T
+        remaining = np.random.uniform(0, self.gridscale, size=(n_remaining, 2))
+
+        all_offsets = np.vstack([grid, remaining])
+
+        return all_offsets
 
 
 class BoundaryVectorCells(Neurons):

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -673,6 +673,7 @@ class GridCells(Neurons):
             "gridscale": 0.45,
             "random_orientations": True,
             "random_gridscales": True,
+            "random_phase_offsets": True,
             "min_fr": 0,
             "max_fr": 1,
             "name": "GridCells",


### PR DESCRIPTION
This PR did:
1. Fix the bug when initializing GridCells with `"random_gridscales": False`.
2. Make non-random phase_offsets for GridCells.
    The offsets separate into two parts. One is organized, and the other is random.
    (e.g. if n=101, then 100 cells have organized phase offsets, and the last 1 cell's phase offset is random.)