### PR TITLE
Class method to retrieve a default parameters of a class

### DIFF
--- a/ratinabox/Agent.py
+++ b/ratinabox/Agent.py
@@ -1,6 +1,7 @@
 import ratinabox
 
 import copy
+import pprint
 import numpy as np
 import os
 import matplotlib
@@ -76,7 +77,7 @@ class Agent:
         """
         self.Environment = Environment
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         utils.update_class_params(self, self.params, get_all_defaults=True)
@@ -125,6 +126,13 @@ class Agent:
                 Other plotting functions are available."""
             )
         return
+
+    @classmethod
+    def get_all_default_params(cls, verbose=True):
+        all_default_params = utils.collect_all_default_params(cls)
+        if verbose:
+            pprint.pprint(all_default_params)
+        return all_default_params
 
     def update(self, dt=None, drift_velocity=None, drift_to_random_strength_ratio=1):
         """Movement policy update.

--- a/ratinabox/Environment.py
+++ b/ratinabox/Environment.py
@@ -1,6 +1,7 @@
 import ratinabox
 
 import copy
+import pprint
 import numpy as np
 import matplotlib
 from matplotlib import pyplot as plt
@@ -64,7 +65,7 @@ class Environment:
             params (dict, optional). Defaults to {}.
         """
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         utils.update_class_params(self, self.params, get_all_defaults=True)
@@ -163,6 +164,13 @@ class Environment:
 
         return
 
+    @classmethod
+    def get_all_default_params(cls, verbose=True):
+        all_default_params = utils.collect_all_default_params(cls)
+        if verbose:
+            pprint.pprint(all_default_params)
+        return all_default_params
+    
     def add_wall(self, wall):
         """Add a wall to the (2D) environment.
         Extends self.walls array to include one new wall.

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -1,6 +1,7 @@
 import ratinabox
 
 import copy
+import pprint
 import numpy as np
 import matplotlib
 from matplotlib import pyplot as plt
@@ -43,7 +44,7 @@ class Neurons:
                      params={}): #<-- do not change these
 
 
-            self.params = copy.deepcopy(self.__class__.default_params) # it is best to retrieve the default param dictionary as self.__class__. Then, make sure to deepcopy it, as only making a shallow copy can have unintended consequences (i.e., any modifications to it would be propagated to ALL instances of this class!).
+            self.params = copy.deepcopy(__class__.default_params) # to get the default param dictionary of the current class, defined in the preamble, use __class__. Then, make sure to deepcopy it, as only making a shallow copy can have unintended consequences (i.e., any modifications to it would be propagated to ALL instances of this class!).
             self.params.update(params)
 
             super().__init__(Agent,self.params)
@@ -104,7 +105,7 @@ class Neurons:
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)
         self.params.update(params)
 
         utils.update_class_params(self, self.params, get_all_defaults=True)
@@ -122,6 +123,13 @@ class Neurons:
             print(
                 f"\nA Neurons() class has been initialised with parameters f{self.params}. Use Neurons.update() to update the firing rate of the Neurons to correspond with the Agent.Firing rates and spikes are saved into the Agent.history dictionary. Plot a timeseries of the rate using Neurons.plot_rate_timeseries(). Plot a rate map of the Neurons using Neurons.plot_rate_map()."
             )
+
+    @classmethod
+    def get_all_default_params(cls, verbose=True):
+        all_default_params = utils.collect_all_default_params(cls)
+        if verbose:
+            pprint.pprint(all_default_params)
+        return all_default_params
 
     def update(self):
         # update noise vector
@@ -670,7 +678,7 @@ class PlaceCells(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)
@@ -848,7 +856,7 @@ class GridCells(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)      
         self.params.update(params)
 
         super().__init__(Agent, self.params)
@@ -987,7 +995,7 @@ class BoundaryVectorCells(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)
@@ -1274,7 +1282,7 @@ class ObjectVectorCells(Neurons):
     def __init__(self, Agent, params={}):
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         assert (
@@ -1459,7 +1467,7 @@ class HeadDirectionCells(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         if self.Agent.Environment.dimensionality == "2D":
@@ -1582,7 +1590,7 @@ class VelocityCells(HeadDirectionCells):
             params (dict, optional). Defaults to {}."""
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         self.one_sigma_speed = self.Agent.speed_mean + self.Agent.speed_std
@@ -1634,7 +1642,7 @@ class SpeedCell(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)
@@ -1712,7 +1720,7 @@ class FeedForwardLayer(Neurons):
     def __init__(self, Agent, params={}):
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)

--- a/ratinabox/contribs/FieldOfViewNeurons.py
+++ b/ratinabox/contribs/FieldOfViewNeurons.py
@@ -42,7 +42,7 @@ class FieldOfViewNeurons(Neurons):
 
     def __init__(self, Agent, params={}):
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         # tile FoV within angular and distance specifications given as params

--- a/ratinabox/contribs/PhasePrecessingPlaceCells.py
+++ b/ratinabox/contribs/PhasePrecessingPlaceCells.py
@@ -49,7 +49,7 @@ class PhasePrecessingPlaceCells(PlaceCells):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)

--- a/ratinabox/contribs/PlaneWaveNeurons.py
+++ b/ratinabox/contribs/PlaneWaveNeurons.py
@@ -38,7 +38,7 @@ class PlaneWaveNeurons(Neurons):
 
         self.Agent = Agent
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Agent, self.params)

--- a/ratinabox/contribs/ThetaSequenceAgent.py
+++ b/ratinabox/contribs/ThetaSequenceAgent.py
@@ -40,7 +40,7 @@ class ThetaSequenceAgent(Agent):
 
         self.Environment = Environment
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         super().__init__(Environment, self.params)

--- a/ratinabox/contribs/ValueNeuron.py
+++ b/ratinabox/contribs/ValueNeuron.py
@@ -44,7 +44,7 @@ class ValueNeuron(FeedForwardLayer):
 
     def __init__(self, Agent, params={}):
 
-        self.params = copy.deepcopy(self.__class__.default_params)        
+        self.params = copy.deepcopy(__class__.default_params)        
         self.params.update(params)
 
         self.params["input_layers"] = [self.params["input_layer"]]

--- a/ratinabox/utils.py
+++ b/ratinabox/utils.py
@@ -751,13 +751,10 @@ def check_params(Obj, param_keys):
         unexpected_keys = ", ".join(
             [f"'{attr}'" for attr in unexpected_keys]
             )
-        object_name = str(Obj)
-        if hasattr(Obj, "name"):
-            object_name = f"{object_name} ('{Obj.name}')"
 
         warnings.warn(
             f"Found {num} unexpected params key(s) while initializing "
-            f"{object_name}: {unexpected_keys}"
+            f"{obj_class.__name__} object: {unexpected_keys}."
             )
     
     return unexpected_keys


### PR DESCRIPTION
Added a class method to Agent, Environment and Neurons to retrieve a class' default parameters.
Changed the default parameters deep copy in the __init__() calls to retrieve the class default parameters for the class in which the __init__ is situated (not the instance's class default parameters, which could belong to a Child class). 
Changed unexpected parameter keys warning to specify class name.