### PR TITLE
Made collect_all_params more flexible

### DIFF
--- a/ratinabox/Agent.py
+++ b/ratinabox/Agent.py
@@ -131,7 +131,7 @@ class Agent:
     @classmethod
     def get_all_default_params(cls, verbose=False):
         """Returns a dictionary of all the default parameters of the class, including those inherited from its parents."""
-        all_default_params = utils.collect_all_default_params(cls)
+        all_default_params = utils.collect_all_params(cls, dict_name="default_params")
         if verbose:
             pprint.pprint(all_default_params)
         return all_default_params

--- a/ratinabox/Environment.py
+++ b/ratinabox/Environment.py
@@ -169,7 +169,7 @@ class Environment:
     @classmethod
     def get_all_default_params(cls, verbose=False):
         """Returns a dictionary of all the default parameters of the class, including those inherited from its parents."""
-        all_default_params = utils.collect_all_default_params(cls)
+        all_default_params = utils.collect_all_params(cls, dict_name="default_params")
         if verbose:
             pprint.pprint(all_default_params)
         return all_default_params

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -128,7 +128,7 @@ class Neurons:
     @classmethod
     def get_all_default_params(cls, verbose=False):
         """Returns a dictionary of all the default parameters of the class, including those inherited from its parents."""
-        all_default_params = utils.collect_all_default_params(cls)
+        all_default_params = utils.collect_all_params(cls, dict_name="default_params")
         if verbose:
             pprint.pprint(all_default_params)
         return all_default_params


### PR DESCRIPTION
`collect_all_default_params` changed to `collect_all_params` to allow the function to be used with user-defined class dictionaries.
Fixed the None return following the warning if the params dictionary doesn't exist.