### PR TITLE
Add scikit-learn to “test” extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ include_package_data = False
 [options.extras_require]
 test = 
     pytest 
+    scikit-learn
 
 [options.package_data]
 ratinabox = data/*


### PR DESCRIPTION
It is used in `tests/test_advanced.py`:

https://github.com/TomGeorge1234/RatInABox/blob/b8d9103bb77bbb42ddeb1abdfcfa2b3c126d43b7/tests/test_advanced.py#L5

https://github.com/TomGeorge1234/RatInABox/blob/b8d9103bb77bbb42ddeb1abdfcfa2b3c126d43b7/tests/test_advanced.py#L13-L14