### PR TITLE
TaskEnvironments: flexible observation space and action_space bug

### DIFF
--- a/ratinabox/contribs/TaskEnvironment.py
+++ b/ratinabox/contribs/TaskEnvironment.py
@@ -159,7 +159,7 @@ class TaskEnvironment(Environment, pettingzoo.ParallelEnv):
             # Add the agent's action space to the environment's action spaces
             # dict
             D = int(self.dimensionality[0])
-            self.action_spaces[name] = Box(low=0, high=maxvel, shape=(D,))
+            self.action_spaces[name] = Box(low=-maxvel, high=maxvel, shape=(D,))
 
             # Add the agent's observation space to the environment's 
             # observation spaces dict

--- a/ratinabox/contribs/TaskEnvironment.py
+++ b/ratinabox/contribs/TaskEnvironment.py
@@ -266,10 +266,16 @@ class TaskEnvironment(Environment, pettingzoo.ParallelEnv):
         """
         return False
 
+    def seed(self, seed=None):
+        """ Seed the random number generator """
+        np.random.seed(seed)
+
     def reset(self, seed=None, return_info=False, options=None):
         """
         How to reset the task when finisedh
         """
+        if seed is not None:
+            self.seed(seed)
         if self.verbose:
             print("Resetting")
         if len(self.episodes['start']) > 0:
@@ -646,7 +652,7 @@ class Reward():
         "exponential": [2],
         "none":        []
     }
-    def __init__(self, init_state, dt=0.01,
+    def __init__(self, init_state=1, dt=0.01,
                  expire_clock=None, decay=None,
                  decay_knobs=[], 
                  external_drive:Union[FunctionType,None]=None,
@@ -1024,7 +1030,7 @@ class GoalCache():
             print("Clearing goals")
         self.goals.clear()
 
-    def reset(self):
+    def reset(self, seed=None):
         """
         Reset the goal cache for the next episode -- drawing from
         self.reset_goals. It selects self.reset_n_goals from the pool

--- a/tests/test_taskenv.py
+++ b/tests/test_taskenv.py
@@ -81,6 +81,10 @@ def test_drift_velocity_not_nan(drift_velocity):
     assert not any((np.isnan(driftvec).any() 
                     for driftvec in drift_velocity.values()))
 
+def test_reward_is_not_nan(EnvWithAgents, drift_velocity):
+    _, reward, _, _, _ = EnvWithAgents.step(drift_velocity)
+    assert not np.isnan(list(reward.values())).any()
+
 def test_agent_can_reach_goal(EnvWithAgents: SpatialGoalEnvironment,
                               less_than_steps=10_000):
     """ Test that the agent can reach the goal """


### PR DESCRIPTION
flexible `observation_space`, fixed `action_space` bug, and added pettingzoo's `seed=` option for `reset()`.