### PR TITLE
Restructure FOV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **__pycache__**
 **egg-info**
+
+
+figures/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**__pycache__**
+**egg-info**

--- a/ratinabox/contribs/FieldOfViewNeurons.py
+++ b/ratinabox/contribs/FieldOfViewNeurons.py
@@ -96,13 +96,13 @@ class FieldOfViewNeurons(Neurons):
         # initialise BVCs and set their distance/angular preferences and widths
         if self.params["cell_type"] == "BVC":
             self.params["n"] = self.n_manifold
-            super().__init__(Agent, self.params)
-            
-            
+                       
         elif self.params["cell_type"] == "OVC":
             self.unique_objects = np.unique(Agent.Environment.objects["object_types"])
             self.params["n"] = self.n_manifold * len(self.unique_objects)  # one manifold for each unique object type
-            super().__init__(Agent, self.params)
+        
+        
+        super().__init__(Agent, self.params)
             
 
     def display_manifold(self, fig=None, ax=None, t=None, object_type=0, **kwargs):


### PR DESCRIPTION
Solves #56 

I did try to make this backward compatible but that might actually result in circular callbacks to the `__init__` functions. There might be a way around that but in general will involve adopting bad practices and will not be maintainable in the long run, which is what we are trying to achieve here. 

Current 
```python
FoVs_OVC = FieldOfViewNeurons(Ag,params={'cell_type':'OVC'})
FoVs_BVC = FieldOfViewNeurons(Ag,params={'cell_type':'BVC'})
FoVs_WC = FieldOfViewNeuronsAg,params={'cell_type':'BVC',"FoV_angles":[75,105],"FoV_distance":[0.1,0.2],"spatial_resolution":0.02})
```


Post the change 

```python 
FoVs_OVC = FieldOfViewNeurons.get_instance(Ag,params={'cell_type':'OVC'})
FoVs_BVC = FieldOfViewNeurons.get_instance(Ag,params={'cell_type':'BVC'})
FoVs_WC = FieldOfViewNeurons.get_instance(Ag,params={'cell_type':'BVC',"FoV_angles":[75,105],"FoV_distance":[0.1,0.2],"spatial_resolution":0.02})
```

I tried to implement the factory method. This in my opinion is a small change in the API considering it rid of the `super` object in the FOV class. What do you think? 