### PR TITLE
Fix union to work with python versions <3.10

### DIFF
--- a/ratinabox/utils.py
+++ b/ratinabox/utils.py
@@ -7,6 +7,7 @@ import os
 import warnings
 from datetime import datetime
 from scipy import stats as stats
+from typing import Union
 import ratinabox
 
 """OTHER USEFUL FUNCTIONS"""
@@ -1076,7 +1077,7 @@ def create_diverging_radial_assembly(distance_range: list = [0.01, 0.2],
 
 
 def create_random_assembly(distance_distribution: str = "uniform",
-                        distance_distribution_params: list| tuple = [0.0, 0.3],
+                        distance_distribution_params: Union[list, tuple] = [0.0, 0.3],
                         angle_spread_degrees: float = 15,
                         beta: float = 12,
                         xi: float = 0.08, 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     matplotlib
     scipy 
     shapely
-python_requires = >=3.10
+python_requires = >=3.7
 include_package_data = False
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ratinabox
-version = 1.9.2
+version = 1.9.3
 author = Tom George
 author_email = tomgeorge1@btinternet.com
 project_urls =


### PR DESCRIPTION
Python 3.10 allows you to use the | operator as a shorthand for Union but is not backward compatible. This PR changes the syntax back to use Union from the typing module. 

Also adapts the setup file to include all python versions >3.7, which addresses  https://github.com/TomGeorge1234/RatInABox/issues/79.